### PR TITLE
JRuby support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.so
+*.bundle
+*.dll

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ Style/StringLiterals:
 Style/SpaceBeforeFirstArg:
   Enabled: false
 
-Style/GlobalVars:
+Style/ConditionalAssignment:
   Enabled: false
 
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.0
+  - 2.1
+  - 2.2
   - 2.3.1
+  - jruby-9.1.1.0
 before_install: gem install bundler -v 1.12.3

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ group :development, :test do
   gem "rake"
   gem "rake-compiler"
   gem "rspec"
-  gem "rubocop", "= 0.40.0" 
+  gem "rubocop", "= 0.40.0"
 end

--- a/README.md
+++ b/README.md
@@ -22,19 +22,28 @@ cryptographic keys, initialization vectors, or nonces.
 
 The following random number generators are utilized:
 
-| OS      | RNG                                                 |
-|---------|-----------------------------------------------------|
-| Linux   | [getrandom(2)] if available, otherwise /dev/urandom |
-| Windows | [RtlGenRandom]                                      |
-| OpenBSD | [arc4random(3)] with ChaCha20 CSPRNG (not RC4)      |
-| Others  | [/dev/urandom]                                      |
+| OS      | RNG                                                               |
+|---------|-------------------------------------------------------------------|
+| Linux   | [getrandom(2)] if available, otherwise [/dev/urandom]             |
+| Windows | [RtlGenRandom]                                                    |
+| OpenBSD | [arc4random(3)] with ChaCha20 CSPRNG (not RC4)                    |
+| JRuby   | [SecureRandom.getInstanceStrong] if available, otherwise SHA1PRNG |
+| Others  | [/dev/urandom]                                                    |
 
 [concerns]:      https://bugs.ruby-lang.org/issues/9569
 [libsodium]:     https://github.com/jedisct1/libsodium
 [getrandom(2)]:  http://man7.org/linux/man-pages/man2/getrandom.2.html
+[/dev/urandom]:  http://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/
 [RtlGenRandom]:  https://msdn.microsoft.com/en-us/library/windows/desktop/aa387694(v=vs.85).aspx
 [arc4random(3)]: http://man.openbsd.org/arc4random.3
-[/dev/urandom]:  http://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/
+[SecureRandom.getInstanceStrong]: https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html#getInstanceStrong--
+
+## Supported Platforms
+
+Sysrandom is tested on the following Ruby implementations:
+
+* Ruby (MRI) 2.0, 2.1, 2.2, 2.3
+* JRuby 9.1.1.0
 
 ## Installation
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,14 +3,19 @@ require "rspec/core/rake_task"
 require "rubocop/rake_task"
 require "rake/clean"
 
-require "rake/extensiontask"
-Rake::ExtensionTask.new("sysrandom") do |ext|
-  ext.ext_dir = "ext/sysrandom"
+unless defined? JRUBY_VERSION
+  require "rake/extensiontask"
+  Rake::ExtensionTask.new("sysrandom_ext") do |ext|
+    ext.ext_dir = "ext/sysrandom"
+  end
 end
 
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
-task default: %w(compile spec rubocop)
+default_tasks = %w(spec rubocop)
+default_tasks.unshift("compile") unless defined?(JRUBY_VERSION)
+
+task default: default_tasks
 
 CLEAN.include "**/*.o", "**/*.so", "**/*.bundle", "pkg", "tmp"

--- a/ext/sysrandom/extconf.rb
+++ b/ext/sysrandom/extconf.rb
@@ -1,4 +1,4 @@
 require "mkmf"
 
-dir_config "sysrandom"
-create_makefile "sysrandom"
+dir_config "sysrandom_ext"
+create_makefile "sysrandom_ext"

--- a/ext/sysrandom/sysrandom_ext.c
+++ b/ext/sysrandom/sysrandom_ext.c
@@ -11,11 +11,12 @@ static VALUE Sysrandom_random_bytes(int argc, VALUE *argv, VALUE self);
 /* From randombytes_sysrandom.c */
 void __randombytes_sysrandom_buf(void * const buf, const size_t size);
 
-void Init_sysrandom()
+void Init_sysrandom_ext()
 {
     mSysrandom = rb_define_module("Sysrandom");
 
     rb_define_singleton_method(mSysrandom, "random_bytes", Sysrandom_random_bytes, -1);
+    rb_define_method(mSysrandom, "random_bytes", Sysrandom_random_bytes, -1);
 }
 
 /**

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,3 +1,0 @@
-*.so
-*.bundle
-*.dll

--- a/lib/sysrandom.rb
+++ b/lib/sysrandom.rb
@@ -1,0 +1,26 @@
+require "sysrandom/version"
+
+# Secure random number generation using system RNG facilities
+module Sysrandom
+  module_function
+
+  if defined?(JRUBY_VERSION)
+    require "java"
+
+    if java.security.SecureRandom.respond_to?(:getInstanceStrong)
+      @_java_secure_random = java.security.SecureRandom.getInstanceStrong
+    else
+      @_java_secure_random = java.security.SecureRandom.getInstance("SHA1PRNG")
+    end
+
+    def random_bytes(n = 16)
+      raise ArgumentError, "negative string size" if n < 0
+
+      bytes = Java::byte[n].new
+      @_java_secure_random.nextBytes(bytes)
+      String.from_java_bytes(bytes)
+    end
+  else
+    require "sysrandom_ext"
+  end
+end

--- a/lib/sysrandom/version.rb
+++ b/lib/sysrandom/version.rb
@@ -1,0 +1,3 @@
+module Sysrandom
+  VERSION = "0.1.0".freeze
+end

--- a/spec/sysrandom_spec.rb
+++ b/spec/sysrandom_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Sysrandom do
   describe ".random_bytes" do
-    it "creates random bytes" do
+    it "creates strings with random bytes" do
       string = described_class.random_bytes
       expect(string).to be_a String
 
@@ -10,12 +10,18 @@ RSpec.describe Sysrandom do
       expect(string).to_not eq string2 # randomness is hard to test for
     end
 
-    it "creates strings of length 16 by default" do
-      expect(described_class.random_bytes.size).to eq 16 # SecureRandom's wacky default string size
-    end
-
     it "honors its length argument" do
       expect(described_class.random_bytes(42).size).to eq 42
+    end
+
+    # SecureRandom's wacky default string size
+    it "creates strings of length 16 by default" do
+      expect(described_class.random_bytes.size).to eq 16 
+    end
+
+    # SecureRandom compatibility
+    it "returns an empty string when given a length of 0" do
+      expect(described_class.random_bytes(0)).to be_empty
     end
   end
 end

--- a/sysrandom.gemspec
+++ b/sysrandom.gemspec
@@ -1,6 +1,10 @@
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "sysrandom/version"
+
 Gem::Specification.new do |spec|
   spec.name          = "sysrandom"
-  spec.version       = "0.0.1"
+  spec.version       = Sysrandom::VERSION
   spec.authors       = ["Tony Arcieri"]
   spec.email         = ["bascule@gmail.com"]
 
@@ -14,5 +18,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.extensions = ["ext/sysrandom/extconf.rb"]
+  if defined? JRUBY_VERSION
+    spec.platform = "java"
+  else
+    spec.extensions = ["ext/sysrandom/extconf.rb"]
+  end
 end


### PR DESCRIPTION
Uses `java.security.SecureRandom.getInstanceStrong` if available, otherwise falls back on `getInstance("SHA1PRNG")`
