### PR TITLE
random_bytes(0) should [perhaps do something other than return an empty string]

### DIFF
--- a/ext/sysrandom/sysrandom_ext.c
+++ b/ext/sysrandom/sysrandom_ext.c
@@ -70,7 +70,7 @@ Sysrandom_random_bytes(int argc, VALUE * argv, VALUE self)
         str = rb_str_new(0, n);
         __randombytes_sysrandom_buf(RSTRING_PTR(str), n);
     } else {
-        str = Qfalse;
+        rb_raise(rb_eArgError, "string size is zero");
     }
 
     return str;

--- a/ext/sysrandom/sysrandom_ext.c
+++ b/ext/sysrandom/sysrandom_ext.c
@@ -70,7 +70,7 @@ Sysrandom_random_bytes(int argc, VALUE * argv, VALUE self)
         str = rb_str_new(0, n);
         __randombytes_sysrandom_buf(RSTRING_PTR(str), n);
     } else {
-        str = rb_str_new2("");
+        str = Qfalse;
     }
 
     return str;

--- a/lib/sysrandom.rb
+++ b/lib/sysrandom.rb
@@ -25,6 +25,7 @@ module Sysrandom
 
     def random_bytes(n = DEFAULT_LENGTH)
       raise ArgumentError, "negative string size" if n < 0
+      return false if n == 0
 
       bytes = Java::byte[n].new
       @_java_secure_random.nextBytes(bytes)

--- a/lib/sysrandom.rb
+++ b/lib/sysrandom.rb
@@ -25,7 +25,7 @@ module Sysrandom
 
     def random_bytes(n = DEFAULT_LENGTH)
       raise ArgumentError, "negative string size" if n < 0
-      return false if n == 0
+      raise ArgumentError, "string size is zero"  if n == 0
 
       bytes = Java::byte[n].new
       @_java_secure_random.nextBytes(bytes)

--- a/spec/sysrandom_spec.rb
+++ b/spec/sysrandom_spec.rb
@@ -37,12 +37,13 @@ RSpec.describe Sysrandom do
 
     # SecureRandom's wacky default string size
     it "creates strings of length 16 by default" do
-      expect(described_class.random_bytes.size).to eq 16 
+      expect(described_class.random_bytes.size).to eq 16
     end
 
-    # SecureRandom compatibility
-    it "returns an empty string when given a length of 0" do
-      expect(described_class.random_bytes(0)).to be_empty
+    # Incompatible with SecureRandom, but 0 should not return an emtpy string!
+    # if anyone /depends/ on that it's time to notice, especially when using this gem
+    it "returns false when given a length of 0" do
+      expect(described_class.random_bytes(0)).to be_falsey
     end
   end
 

--- a/spec/sysrandom_spec.rb
+++ b/spec/sysrandom_spec.rb
@@ -39,12 +39,6 @@ RSpec.describe Sysrandom do
     it "creates strings of length 16 by default" do
       expect(described_class.random_bytes.size).to eq 16
     end
-
-    # Incompatible with SecureRandom, but 0 should not return an emtpy string!
-    # if anyone /depends/ on that it's time to notice, especially when using this gem
-    it "returns false when given a length of 0" do
-      expect(described_class.random_bytes(0)).to be_falsey
-    end
   end
 
   describe ".base64" do


### PR DESCRIPTION
If people want to use this gem and have safe functionality, this should really not return an empty string (PHP anyone?). I'm aware this breaks SecureRandom compat. but I think it's OK to do so if someone uses this gem.
