### PR TITLE
Upstream libsodium change: wait for /dev/random to be seeded before reading from /dev/urandom

### DIFF
--- a/ext/sysrandom/randombytes_sysrandom.c
+++ b/ext/sysrandom/randombytes_sysrandom.c
@@ -1,5 +1,5 @@
 /*
- * __randombytes_sysrandom.c: adapted from libsodium
+ * randombytes_sysrandom.c: adapted from libsodium
  * Copyright (c) 2013-2016 Frank Denis <j at pureftpd dot org>
  * https://github.com/jedisct1/libsodium
  */
@@ -12,6 +12,7 @@
 #endif
 #ifdef __linux__
 # include <sys/syscall.h>
+# include <poll.h>
 #endif
 
 #include <assert.h>
@@ -102,6 +103,33 @@ safe_read(const int fd, void * const buf_, size_t size)
 #endif
 
 #ifndef _WIN32
+# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM)
+static int
+randombytes_block_on_dev_random(void)
+{
+    struct pollfd pfd;
+    int           fd;
+    int           pret;
+
+    fd = open("/dev/random", O_RDONLY);
+    if (fd == -1) {
+        return 0;
+    }
+    pfd.fd = fd;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    do {
+        pret = poll(&pfd, 1, -1);
+    } while (pret < 0 && (errno == EINTR || errno == EAGAIN));
+    if (pret != 1) {
+        (void) close(fd);
+        errno = EIO;
+        return -1;
+    }
+    return close(fd);
+}
+# endif
+
 static int
 __randombytes_sysrandom_random_dev_open(void)
 {
@@ -116,6 +144,11 @@ __randombytes_sysrandom_random_dev_open(void)
     const char **      device = devices;
     int                fd;
 
+# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM)
+    if (randombytes_block_on_dev_random() != 0) {
+        return -1;
+    }
+# endif
     do {
         fd = open(*device, O_RDONLY);
         if (fd != -1) {
@@ -145,7 +178,7 @@ __randombytes_sysrandom_random_dev_open(void)
 /* LCOV_EXCL_STOP */
 }
 
-# ifdef SYS_getrandom
+# if defined(SYS_getrandom) && defined(__NR_getrandom)
 static int
 _randombytes_linux_getrandom(void * const buf, const size_t size)
 {
@@ -186,7 +219,7 @@ __randombytes_sysrandom_init(void)
 {
     const int     errno_save = errno;
 
-# ifdef SYS_getrandom
+# if defined(SYS_getrandom) && defined(__NR_getrandom)
     {
         unsigned char fodder[16];
 
@@ -240,7 +273,7 @@ __randombytes_sysrandom_buf(void * const buf, const size_t size)
     assert(size <= ULONG_LONG_MAX);
 #endif
 #ifndef _WIN32
-# ifdef SYS_getrandom
+# if defined(SYS_getrandom) && defined(__NR_getrandom)
     if (stream.getrandom_available != 0) {
         if (randombytes_linux_getrandom(buf, size) != 0) {
             abort();


### PR DESCRIPTION
This change polls /dev/random to ensure it's readable before accepting bytes from /dev/urandom for the first time. This ensures the /dev/urandom RNG has been properly seeded.
