### PR TITLE
Return empty string on random_bytes(0) as SecureRandom does. Add some addl tests.

### DIFF
--- a/ext/sysrandom/sysrandom_ext.c
+++ b/ext/sysrandom/sysrandom_ext.c
@@ -45,7 +45,8 @@ Sysrandom_random_uint32(VALUE self)
  *
  * The argument n specifies how long the resulting string should be.
  *
- * For compatibility with SecureRandom, if n is not specified, 16 is assumed.
+ * For compatibility with SecureRandom, if n is not specified, 16 is assumed,
+ * and if n is 0, an empty string is returned.
  *
  * The resulting string may contain any byte (i.e. "x00" - "xff")
  *
@@ -70,7 +71,8 @@ Sysrandom_random_bytes(int argc, VALUE * argv, VALUE self)
         str = rb_str_new(0, n);
         __randombytes_sysrandom_buf(RSTRING_PTR(str), n);
     } else {
-        rb_raise(rb_eArgError, "string size is zero");
+        // n == 0, return empty string
+        str = rb_str_new(0, 0);
     }
 
     return str;

--- a/lib/sysrandom.rb
+++ b/lib/sysrandom.rb
@@ -28,7 +28,7 @@ module Sysrandom
 
     def random_bytes(n = DEFAULT_LENGTH)
       raise ArgumentError, "negative string size" if n < 0
-      raise ArgumentError, "string size is zero"  if n == 0
+      return "" if n == 0
 
       bytes = Java::byte[n].new
       @_java_secure_random.nextBytes(bytes)

--- a/spec/sysrandom_spec.rb
+++ b/spec/sysrandom_spec.rb
@@ -43,6 +43,40 @@ RSpec.describe Sysrandom do
     it "returns an empty string if zero bytes requested" do
       expect(described_class.random_bytes(0)).to eq ""
     end
+
+    it "generates a random binary string of specified length" do
+      (1..64).each do |idx|
+        bytes = described_class.random_bytes(idx)
+        expect(bytes).to be_a String
+        expect(bytes.size).to eq idx
+      end
+
+      expect(described_class.random_bytes(2.2).length).to eq(2)
+    end
+
+    it "generates different binary strings with subsequent invocations" do
+      # quick and dirty check, but good enough
+      values = []
+      256.times do
+        val = described_class.random_bytes
+        # make sure the random bytes are not repeating
+        expect(values.include?(val)).to be(false)
+        values << val
+      end
+    end
+
+    it "raises ArgumentError on negative arguments" do
+      expect { described_class.random_bytes(-1) }.to raise_error(ArgumentError, "negative string size")
+    end
+
+    it "calls to_int on the number passed as an arg" do
+      # jruby doesn't do this test
+      unless defined? JRUBY_VERSION
+        obj = double("to_int")
+        expect(obj).to receive(:to_int) { 5 }
+        expect(described_class.random_bytes(obj).size).to eq(5)
+      end
+    end
   end
 
   describe ".base64" do

--- a/spec/sysrandom_spec.rb
+++ b/spec/sysrandom_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Sysrandom do
     it "creates strings of length 16 by default" do
       expect(described_class.random_bytes.size).to eq 16
     end
+
+    it "returns an empty string if zero bytes requested" do
+      expect(described_class.random_bytes(0)).to eq ""
+    end
   end
 
   describe ".base64" do


### PR DESCRIPTION
Pulled in some additional specs for `random_bytes` that did not have current coverage from rubyspec/jruby. No issues found.

https://github.com/ruby/spec/blob/e8c46ebbf76d860a0dd50a5f45556d3bf7796ec5/library/securerandom/random_bytes_spec.rb

Skip one test for JRUBY since it does not call `to_int` as MRI does.

https://github.com/jruby/jruby/blob/915993886ae6663586d893b7d237f750068aceb5/lib/ruby/truffle/rubysl/rubysl-securerandom/lib/rubysl/securerandom/securerandom.rb
