### PR TITLE
Argument handling fixups (fixes #15)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 sudo: false
 language: ruby
+
+branches:
+  only:
+    - master
+
 rvm:
   - 2.0
   - 2.1
   - 2.2
   - 2.3.1
   - jruby-9.1.1.0
+
 before_install: gem install bundler -v 1.12.3

--- a/ext/sysrandom/sysrandom_ext.c
+++ b/ext/sysrandom/sysrandom_ext.c
@@ -58,10 +58,14 @@ Sysrandom_random_bytes(int argc, VALUE * argv, VALUE self)
     int n;
 
     if (rb_scan_args(argc, argv, "01", &n_obj) == 1) {
-        n = NUM2INT(n_obj);
+        if(n_obj == Qnil) {
+            n = DEFAULT_N_BYTES;
+        } else {
+            n = NUM2INT(n_obj);
 
-        if(n < 0) {
-          rb_raise(rb_eArgError, "negative string size");
+            if(n < 0) {
+              rb_raise(rb_eArgError, "negative string size");
+            }
         }
     } else {
         n = DEFAULT_N_BYTES;

--- a/lib/sysrandom.rb
+++ b/lib/sysrandom.rb
@@ -26,7 +26,8 @@ module Sysrandom
       @_java_secure_random.nextLong & 0xFFFFFFFF
     end
 
-    def random_bytes(n = DEFAULT_LENGTH)
+    def random_bytes(n = nil)
+      n ||= DEFAULT_LENGTH
       raise ArgumentError, "negative string size" if n < 0
       return "" if n == 0
 
@@ -49,15 +50,16 @@ module Sysrandom
     end
   end
 
-  def base64(n = DEFAULT_LENGTH)
+  def base64(n = nil)
     Base64.encode64(random_bytes(n)).chomp
   end
 
-  def urlsafe_base64(n = DEFAULT_LENGTH)
-    Base64.urlsafe_encode64(random_bytes(n)).chomp
+  def urlsafe_base64(n = nil, padding = false)
+    result = Base64.urlsafe_encode64(random_bytes(n)).chomp
+    padding ? result : result.tr("=", "")
   end
 
-  def hex(n = DEFAULT_LENGTH)
+  def hex(n = nil)
     random_bytes(n).unpack("h*").first
   end
 

--- a/spec/sysrandom_spec.rb
+++ b/spec/sysrandom_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Sysrandom do
       expect(described_class.random_bytes(42).size).to eq 42
     end
 
+    it "allows nil as a length argument" do
+      expect(described_class.random_bytes(nil).size).to eq 16
+    end
+
     # SecureRandom's wacky default string size
     it "creates strings of length 16 by default" do
       expect(described_class.random_bytes.size).to eq 16
@@ -94,8 +98,16 @@ RSpec.describe Sysrandom do
   end
 
   describe ".urlsafe_base64" do
-    it "creates random urlsafe_base64 strings" do
-      base64 = described_class.urlsafe_base64(16)
+    it "creates unpadded strings by default" do
+      expect(described_class.urlsafe_base64).not_to include("=")
+    end
+
+    it "optionally creates padded strings" do
+      expect(described_class.urlsafe_base64(nil, true)).to include("=")
+    end
+
+    it "creates valid urlsafe_base64 strings" do
+      base64 = described_class.urlsafe_base64(nil, true)
       expect(Base64.urlsafe_decode64(base64)).to be_a String
     end
   end


### PR DESCRIPTION
- Use "nil" as the default "n" in methods that take an n-bytes param
- Add "padding" argument to urlsafe_base64, false by default