### PR TITLE
Replace Fixnum references with Integer (fixes #18)

### DIFF
--- a/ext/sysrandom/sysrandom_ext.c
+++ b/ext/sysrandom/sysrandom_ext.c
@@ -26,7 +26,7 @@ void Init_sysrandom_ext()
 
 /**
  *  call-seq:
- *    Sysrandom#__random_uint32 -> Fixnum
+ *    Sysrandom#__random_uint32 -> Integer
  *
  * Generates a random unsigned 32-bit integer using the OS CSPRNG
  *

--- a/lib/sysrandom.rb
+++ b/lib/sysrandom.rb
@@ -46,7 +46,7 @@ module Sysrandom
       result
     else
       result *= n
-      n.is_a?(Fixnum) ? result.floor : result
+      n.is_a?(Integer) ? result.floor : result
     end
   end
 

--- a/spec/sysrandom_spec.rb
+++ b/spec/sysrandom_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Sysrandom do
       expect(n).to be < 1
     end
 
-    it "returns a Fixnum if given a Fixnum as an argument" do
-      expect(described_class.random_number(42)).to be_a Fixnum
+    it "returns an Integer if given an Integer as an argument" do
+      expect(described_class.random_number(42)).to be_an Integer
     end
 
     it "returns a Float if given a Float as an argument" do


### PR DESCRIPTION
Fixnum was deprecated in Ruby 2.4.0